### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "rust"
+run = "cargo build"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # RUST GB EMULATOR
+[![Run on Repl.it](https://repl.it/badge/github/ngynkvn/rust-emu)](https://repl.it/github/ngynkvn/rust-emu)
 Cause that hasnt been done before.
 
 - The code is extremely rough. View at your own discretion.


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@ngynkvn/rust-emu).